### PR TITLE
.cei parser, plus some other stuff along for the ride

### DIFF
--- a/salmon_lib/parsers/cei.py
+++ b/salmon_lib/parsers/cei.py
@@ -1,0 +1,16 @@
+"""
+let's do this
+this file is arcane. quoth the manual:
+
+The *.cei files (see Fig. 2.11) is used to set catch ceilings which are the
+primary means selected by the PSC to reduce stock exploitation rates. The *.cei
+file is used: (1) to specify fisheries with ceilings; (2) to set ceiling levels
+(catch levels); and (3) to allow you to force Model catches to equal the
+ceiling.
+
+
+"""
+
+
+def parse_cei():
+    pass

--- a/salmon_lib/parsers/cei.py
+++ b/salmon_lib/parsers/cei.py
@@ -45,6 +45,20 @@ def parse_cei(file):
         "fishery": []
     }
 
-    # and then a miracle occurs...
-
+    # now for the fun stuff. From some file-surgery testing, I believe that
+    # CRiSP Harvest expects a comment line before each fishery, and skips it.
+    # Next, it requires a line the fishery ID number. Then, it requires one
+    # line for every year from start_base to the end of ceil_change_years.
+    # I think. Or, uh...well, let's just say for now that it expects the end of
+    # ceil_change_years to be the last year listed.
+    i = 7
+    while i < len(lines):
+        i += 1
+        # it's too late to write code. notes: go through and populate a dict?
+        # fishery = {
+        # id = (int),
+        # years = [{year: int, catch: int, note: str}, ...]
+        # num_force: int,
+        # years_force: [list of ints, len=num_force]
+        # }
     return cei

--- a/salmon_lib/parsers/cei.py
+++ b/salmon_lib/parsers/cei.py
@@ -8,9 +8,43 @@ file is used: (1) to specify fisheries with ceilings; (2) to set ceiling levels
 (catch levels); and (3) to allow you to force Model catches to equal the
 ceiling.
 
+Fig. 2.11 looks like this:
+
+1979    ,       Start of base period
+1984    ,       End of base period
+1985    ,       First year of ceiling management
+1998    ,       Last year for ceiling management
+11      ,       Number of fisheries with ceilings
+7       ,       Number of ceiling level changes
+1986 1987 1988 1990 1991 1992 , years to change ceilings
+.................. S.E. Alaska Troll (excluding hatchery add-ON)......
+1       ,       1st Fishery Number
+        338000  ,1979,catch
+                ... continue for each year
+        230712  ,1990,catch [sic: this is the number for 1991 in the real file]
+        162995  ,1992, THROUGH LAST YEAR OF CLG MGMT
+        8       ,Number of years to force ceilings
+        1985 1986 1987 1988 1989 1990 1991 1992 , years to force
+.................. (etc for remaining Fisheries)
+
+The actual base.cei file looks different mainly in whitespace...
 
 """
 
 
-def parse_cei():
-    pass
+def parse_cei(file):
+    lines = file.readlines()
+    cei = {
+        "start_base": int(lines[0].split(",")[0].strip()),
+        "end_base": int(lines[1].split(",")[0].strip()),
+        "start_ceil": int(lines[2].split(",")[0].strip()),
+        "end_ceil": int(lines[3].split(",")[0].strip()),
+        "num_ceil_fisheries": int(lines[4].split(",")[0].strip()),
+        "num_ceil_changes": int(lines[5].split(",")[0].strip()),
+        "ceil_change_years": [int(year) for year in lines[6].split(",")[0].split()],
+        "fishery": []
+    }
+
+    # and then a miracle occurs...
+
+    return cei

--- a/salmon_lib/parsers/fp.py
+++ b/salmon_lib/parsers/fp.py
@@ -15,7 +15,7 @@ This is a terrible format, probably. But that's ok, for now.
 
 def parse_fp(file):
     """parse .fp files. returns a 3D array (nested lists):
-    year x fishery x stock.
+    year x stock x fishery.
     The original base.fp file, for instance, returns a 39x30x25 array."""
     slices = file.read().strip().replace('\r', '').split('\n\n')
     return [[[float(s) for s in line.split()] for line in slice.splitlines()]

--- a/salmon_lib/salmon.py
+++ b/salmon_lib/salmon.py
@@ -156,7 +156,7 @@ class FisheryBuilder:
                         stock_index = self.stock_index(stock)
                         self.sim.stocks[stock_index].policy(i,rate[1])
 
-                for stock in sim.stocks:
+                for stock in self.sim.stocks:
                     if stock.abbreviation in done:
                         pass
                     else:
@@ -177,10 +177,11 @@ class FisheryBuilder:
                     else:
                         stock.policy(i,default)
             elif isinstance(year,float): # year is a single float
-                for stock in sim.stocks:
+                for stock in self.sim.stocks:
                     self.sim.stocks[stock_index].policy(i,year)
 
-        sim.fisheries.append(self)
+        self.sim.fisheries.append(self)
+        return self.sim.fisheries[-1]
 
 class StockBuilder:
     def __init__(self,sim,config=None):
@@ -300,5 +301,5 @@ class StockBuilder:
 
     def build(self):
         self.sim.stocks.append(self)
-        self.index = len(sim.stocks) - 1
+        self.index = len(self.sim.stocks) - 1
         return self.sim.stocks[-1]


### PR DESCRIPTION
alis, in trying to get your test code working, I had to mess with salmon.py a bit, which led to some stuff that ended up in this PR I guess.

For reference, the test code is
```python
from salmon_lib.salmon import *
import pprint

sim = Sim()
stock = StockBuilder(sim).name("Salmon Institute").abbrev("SIBR").hatchery(True).build()

fishery = FisheryBuilder(sim).name("Society for Salmon").exploits([("SIBR",[1,2,3,4])]).policy([[('default',1)]]).build()
pprint.pprint(stock.__dict__)
pprint.pprint(fishery.__dict__)
```
and when it worked it printed
```
default
{'abbreviation': 'SIBR',
 'hatchery': True,
 'index': 0,
 'name': 'Salmon Institute',
 'policies': [[1]],
 'rates': [[1, 2, 3, 4]],
 'sim': <salmon_lib.salmon.Sim object at 0x109c06f50>}
{'exploitations': [('SIBR', [1, 2, 3, 4])],
 'name': 'Society for Salmon',
 'policy': [[('default', 1)]],
 'sim': <salmon_lib.salmon.Sim object at 0x109c06f50>}
```

I had to add `self.` in front of a bunch of `sim` mentions in `build(self)` for both objects, which I *think* is correct? And I had to add a return statement for the fishery `build(self)`. I infer that this latter change is what allowed `fishery` to have a `fishery.__dict__` at all, but uh, I don't really know what I'm doing here.